### PR TITLE
fix: 게시글 목록 조회시 dto에 생성 날짜도 포함하도록 수정

### DIFF
--- a/src/main/java/com/wl2c/elswherepostservice/domain/post/model/dto/list/SummarizedGenericPostDto.java
+++ b/src/main/java/com/wl2c/elswherepostservice/domain/post/model/dto/list/SummarizedGenericPostDto.java
@@ -7,6 +7,7 @@ import com.wl2c.elswherepostservice.infra.s3.service.AWSObjectStorageService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -21,6 +22,9 @@ public class SummarizedGenericPostDto {
     @Schema(description = "작성자", example = "익명")
     private final String author;
 
+    @Schema(description = "생성 시각")
+    private final LocalDateTime createdAt;
+
     @Schema(description = "본문", example = "게시글 본문")
     private final String body;
 
@@ -34,6 +38,7 @@ public class SummarizedGenericPostDto {
         this.id = post.getId();
         this.title = post.getTitle();
         this.author = nickname;
+        this.createdAt = post.getCreatedAt();
         this.body = slice(post.getBody(), bodySize);
         this.images = PostImageDto.listOf(s3service, post.getImages());
         this.files = PostFileDto.listOf(s3service, post.getFiles());


### PR DESCRIPTION
## Issue 번호
#3 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- 게시글 목록 조회시 dto에 생성 날짜도 포함하도록 수정
